### PR TITLE
#26 Add milestone support to GitHub templates

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -1,3 +1,6 @@
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 SECURITY.md
+pnpm-lock.yaml
+/*.cjs
+node_modules/*

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -45,10 +45,19 @@ body:
           required: true
   - type: checkboxes
     attributes:
-      label: Labels
+      label: Correct Label Selected
       description:
         Make sure to select the appropriate labels for this bug report before
         submitting this issue.
       options:
         - label: This issue has appropriate labels.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Correct Milestone Selected
+      description:
+        Make sure to select the appropriate milestone for this bug report before
+        submitting this issue.
+      options:
+        - label: This issue has appropriate milestone.
           required: true

--- a/.github/ISSUE_TEMPLATE/2.feature_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_suggestion.yml
@@ -19,17 +19,26 @@ body:
     attributes:
       label: Correct Project Selected
       description:
-        Make sure to select the appropriate project for this bug report before
-        submitting this issue.
+        Make sure to select the appropriate project for this feature suggestion
+        before submitting this issue.
       options:
         - label: This issue is linked to the appropriate project.
           required: true
   - type: checkboxes
     attributes:
-      label: Labels
+      label: Correct Label Selected
       description:
-        Make sure to select the appropriate labels for this bug report before
-        submitting this issue.
+        Make sure to select the appropriate labels for this feature suggestion
+        before submitting this issue.
       options:
         - label: This issue has appropriate labels.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Correct Milestone Selected
+      description:
+        Make sure to select the appropriate milestone for this feature
+        suggestion before submitting this issue.
+      options:
+        - label: This issue has appropriate milestone.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,7 @@ _Please ensure that the following items all have checked boxes before setting yo
 - [ ] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 - [ ] The appropriate label has been chosen for this pull request.
 - [ ] The correct project has been selected for this pull request.
+- [ ] The milestone corresponding with the issue has been selected for this pull request.
 - [ ] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
 
 ### Code Standards

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@ package-lock.json
 yarn.lock
 pnpm-lock.yaml
 .next/*
-.github/*
+.github/**/*.md


### PR DESCRIPTION
## Description of Proposed Changes

_What does this pull request propose to change?_

This PR resolves #26 by adding milestone support for the templates used by GitHub for issues and pull requests.

### Type of Change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)

## Testing

_Please describe the tests that you ran to verify your changes, providing instructions so we can reproduce. Also, please list any relevant details for your test configuration._

This code was not tested and can't really be tested until merged into `main`.

## Checklists

_Please ensure that the following items all have checked boxes before setting your pull request as "ready to review". If an item is not relevant to the proposed changes, you may check the corresponding box._

### GitHub

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.

### Code Standards

- [x] Code follows the style guidelines of this project.
- [x] Code comments have been added, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my code.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] These changes generate no new warnings.

### Documentation and Testing

- [x] New and existing unit tests pass locally with these changes.
- [x] Corresponding changes to the documentation have been made.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
